### PR TITLE
Improvements to Search Bar Popover

### DIFF
--- a/argo-scholar/src/components/AddPapersDialog.jsx
+++ b/argo-scholar/src/components/AddPapersDialog.jsx
@@ -1,167 +1,167 @@
-import React from "react";
-import {
-  Button,
-  Classes,
-  Card,
-  Icon,
-  Dialog,
-  Intent,
-  Spinner
-} from "@blueprintjs/core";
-import { observer } from "mobx-react";
-import classnames from "classnames";
-import appState from "../stores/index";
-import PaperResultsCards from "./PaperResultsCards";
+// import React from "react";
+// import {
+//   Button,
+//   Classes,
+//   Card,
+//   Icon,
+//   Dialog,
+//   Intent,
+//   Spinner
+// } from "@blueprintjs/core";
+// import { observer } from "mobx-react";
+// import classnames from "classnames";
+// import appState from "../stores/index";
+// import PaperResultsCards from "./PaperResultsCards";
 
-const corpusIDregex = /^[0-9]+$/; 
-const apiCorpusPrefix = "https://api.semanticscholar.org/v1/paper/CorpusID:";
-const apiKeywordPrefix = "https://api.semanticscholar.org/graph/v1/paper/search?query=";
+// const corpusIDregex = /^[0-9]+$/; 
+// const apiCorpusPrefix = "https://api.semanticscholar.org/v1/paper/CorpusID:";
+// const apiKeywordPrefix = "https://api.semanticscholar.org/graph/v1/paper/search?query=";
 
-@observer
-class AddPapersDialog extends React.Component {
-  constructor(props) {
-    super(props);
-    this._isMounted = false;
-    this.state = {
-      id: 0,
-    };
-  }
+// @observer
+// class AddPapersDialog extends React.Component {
+//   constructor(props) {
+//     super(props);
+//     this._isMounted = false;
+//     this.state = {
+//       id: 0,
+//     };
+//   }
 
-  componentDidMount() {
-    // this.state.query = appState.project.currentQuery;
-    this._isMounted = true;
-  };
+//   componentDidMount() {
+//     // this.state.query = appState.project.currentQuery;
+//     this._isMounted = true;
+//   };
 
-  componentWillUnmount() {
-    this._isMounted = false;
-  };
+//   componentWillUnmount() {
+//     this._isMounted = false;
+//   };
 
-  handleSubmit(event) {
-    let query = appState.project.currentQuery;
-    if (this._isMounted) {
-      if (corpusIDregex.test(query)) {
-        // CorpusID submitted
+//   handleSubmit(event) {
+//     let query = appState.project.currentQuery;
+//     if (this._isMounted) {
+//       if (corpusIDregex.test(query)) {
+//         // CorpusID submitted
         
-        let apiurl = apiCorpusPrefix + query;
+//         let apiurl = apiCorpusPrefix + query;
 
-        fetch(apiurl)
-          .then((res) => {
-            if (res.ok) {
-              return res.json();
-            } else {
-              throw "error";
-            }
-          })
-          .then((response) => {
-            var searches = [];
-            searches.push(response)
-            // for (var i = 0; i < response.data.length; i++) {
-            //   searches.push(response.data[i]);
-            // }
-            appState.project.searchResults = searches;
-            // this.setState({searchResults: searches, search: null});
-          })
-          .catch((error) => {
-            alert("Issue occurred when fetching search results. This may be due to API issues or the CorpusID not being associated with a valid paper.");
-          });
-      } else {
-        // Keyword query
+//         fetch(apiurl)
+//           .then((res) => {
+//             if (res.ok) {
+//               return res.json();
+//             } else {
+//               throw "error";
+//             }
+//           })
+//           .then((response) => {
+//             var searches = [];
+//             searches.push(response)
+//             // for (var i = 0; i < response.data.length; i++) {
+//             //   searches.push(response.data[i]);
+//             // }
+//             appState.project.searchResults = searches;
+//             // this.setState({searchResults: searches, search: null});
+//           })
+//           .catch((error) => {
+//             alert("Issue occurred when fetching search results. This may be due to API issues or the CorpusID not being associated with a valid paper.");
+//           });
+//       } else {
+//         // Keyword query
 
-        var keywordQuery = appState.project.currentQuery; 
-        keywordQuery = keywordQuery.trim().replace(/  +/g, ' ').replace(/ /g, '+');
-        // this.state.search = keywordQuery;
-        // // this.state.query = keywordQuery;
+//         var keywordQuery = appState.project.currentQuery; 
+//         keywordQuery = keywordQuery.trim().replace(/  +/g, ' ').replace(/ /g, '+');
+//         // this.state.search = keywordQuery;
+//         // // this.state.query = keywordQuery;
 
-        let apiurl = apiKeywordPrefix + keywordQuery;
+//         let apiurl = apiKeywordPrefix + keywordQuery;
 
-        fetch(apiurl)
-          .then((res) => {
-            if (res.ok) {
-              return res.json();
-            } else {
-              throw "error";
-            }
-          })
-          .then((response) => {
-            var searches = [];
-            for (var i = 0; i < response.data.length; i++) {
-              searches.push(response.data[i]);
-            }
-            appState.project.searchResults = searches;
-            // this.setState({searchResults: searches, search: keywordQuery});
-            // console.log("addpapersdialog: " + this.state.searchResults);
-          })
-          .catch((error) => {
-            alert("Issue occurred when fetching search results.");
-          });
-      }
-    }
-    event.preventDefault();
-  }
+//         fetch(apiurl)
+//           .then((res) => {
+//             if (res.ok) {
+//               return res.json();
+//             } else {
+//               throw "error";
+//             }
+//           })
+//           .then((response) => {
+//             var searches = [];
+//             for (var i = 0; i < response.data.length; i++) {
+//               searches.push(response.data[i]);
+//             }
+//             appState.project.searchResults = searches;
+//             // this.setState({searchResults: searches, search: keywordQuery});
+//             // console.log("addpapersdialog: " + this.state.searchResults);
+//           })
+//           .catch((error) => {
+//             alert("Issue occurred when fetching search results.");
+//           });
+//       }
+//     }
+//     event.preventDefault();
+//   }
 
-  // handleChange(event) {
-  //   this.searchBy = event.target.value;
-  //   console.log("changed to: ", this.searchBy);
-  // }
+//   // handleChange(event) {
+//   //   this.searchBy = event.target.value;
+//   //   console.log("changed to: ", this.searchBy);
+//   // }
 
-  render() {
-    return (
-      <Dialog
-        iconName="projects"
-        className={classnames({
-          [Classes.DARK]: appState.preferences.darkMode
-        })}
-        isOpen={appState.project.isAddPapersDialogOpen}
-        onClose={() => {
-          appState.project.isAddPapersDialogOpen = false;
-        }}
-        title={`Add Papers`}
-      >
-        <div className={classnames(Classes.DIALOG_BODY)}>
-          <label className="pt-label .modifier">
-            <input
-              class="pt-input pt-fill"
-              type="text"
-              placeholder="Search by paper name or CorpusID"
-              dir="auto"
-              value={appState.project.currentQuery}
-              // value={this.state.query}
-              onChange={event => {
-                appState.project.currentQuery = event.target.value;
-                // this.state.query = event.target.value;
-              }}
-              // onChange={event => this.setState({ query: event.target.value })}
-            />
-          </label>
-          <div className="pt-callout pt-icon-info-sign">
-            <i>Corpus ID</i>, also known as <i>S2CID</i> or <i>S2 corpus ID</i>, is a unique identifier for a paper in the <b>Semantic Scholar</b> database.<br />
-            <a target="_blank" href="https://www.semanticscholar.org/"> Look up the <i>Corpus ID</i> of a paper</a>
+//   render() {
+//     return (
+//       <Dialog
+//         iconName="projects"
+//         className={classnames({
+//           [Classes.DARK]: appState.preferences.darkMode
+//         })}
+//         isOpen={appState.project.isAddPapersDialogOpen}
+//         onClose={() => {
+//           appState.project.isAddPapersDialogOpen = false;
+//         }}
+//         title={`Add Papers`}
+//       >
+//         <div className={classnames(Classes.DIALOG_BODY)}>
+//           <label className="pt-label .modifier">
+//             <input
+//               class="pt-input pt-fill"
+//               type="text"
+//               placeholder="Search by paper name or CorpusID"
+//               dir="auto"
+//               value={appState.project.currentQuery}
+//               // value={this.state.query}
+//               onChange={event => {
+//                 appState.project.currentQuery = event.target.value;
+//                 // this.state.query = event.target.value;
+//               }}
+//               // onChange={event => this.setState({ query: event.target.value })}
+//             />
+//           </label>
+//           <div className="pt-callout pt-icon-info-sign">
+//             <i>Corpus ID</i>, also known as <i>S2CID</i> or <i>S2 corpus ID</i>, is a unique identifier for a paper in the <b>Semantic Scholar</b> database.<br />
+//             <a target="_blank" href="https://www.semanticscholar.org/"> Look up the <i>Corpus ID</i> of a paper</a>
 
-          </div>
-          <div>
-            <PaperResultsCards papers={appState.project.searchResults} query={appState.project.currentQuery} />
-            {/* <PaperResultsCards papers={this.state.searchResults} query={this.state.search} /> */}
-          </div>
-        </div>
+//           </div>
+//           <div>
+//             <PaperResultsCards papers={appState.project.searchResults} query={appState.project.currentQuery} />
+//             {/* <PaperResultsCards papers={this.state.searchResults} query={this.state.search} /> */}
+//           </div>
+//         </div>
 
-        <div className={Classes.DIALOG_FOOTER}>
-          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button
-              className={classnames({
-                [Classes.DISABLED]: !appState.project.currentQuery
-              })}
-              disabled={!appState.project.currentQuery}
-              intent={Intent.PRIMARY}
-              onClick={() => {
-                this.handleSubmit(event);
-              }}
-              text={"Search"}
-            />
-          </div>
-        </div>
-      </Dialog>
-    );
-  }
-}
+//         <div className={Classes.DIALOG_FOOTER}>
+//           <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+//             <Button
+//               className={classnames({
+//                 [Classes.DISABLED]: !appState.project.currentQuery
+//               })}
+//               disabled={!appState.project.currentQuery}
+//               intent={Intent.PRIMARY}
+//               onClick={() => {
+//                 this.handleSubmit(event);
+//               }}
+//               text={"Search"}
+//             />
+//           </div>
+//         </div>
+//       </Dialog>
+//     );
+//   }
+// }
 
-export default AddPapersDialog;
+// export default AddPapersDialog;

--- a/argo-scholar/src/components/SearchBar.jsx
+++ b/argo-scholar/src/components/SearchBar.jsx
@@ -30,12 +30,15 @@ class SearchBar extends React.Component {
     super(props);
     this._isMounted = false; 
     this.state = {
+        searchResults: [],
         query: '', 
         display: false,
     };
 
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleClick = this.handleClick.bind(this);
+    this.handleEnter = this.handleEnter.bind(this);
   }
 
   componentDidMount() {
@@ -50,8 +53,23 @@ class SearchBar extends React.Component {
     this._isMounted && this.setState({query: event.target.value});
   }
 
+  handleClick(event) {
+    this.setState({display: true});
+    // event.preventDefault();
+  } 
+
+  handleEnter(event) {
+    if (event.which === 13) {
+      this.handleSubmit(event);
+    }
+   }
+
   handleSubmit(event) {
-    appState.project.currentQuery = this.state.query;
+    this.setState({display: false})
+    if (this.state.query == "") {
+      return
+    }
+    // appState.project.currentQuery = this.state.query;
     
     if (corpusIDregex.test(this.state.query)) {
       // CorpusID submitted
@@ -72,8 +90,9 @@ class SearchBar extends React.Component {
           // for (var i = 0; i < response.data.length; i++) {
           //   searches.push(response.data[i]);
           // }
-          appState.project.searchResults = searches;
-          appState.project.isAddPapersDialogOpen = true;
+          this.setState({searchResults: searches})
+          this.setState({display: true})
+          // appState.project.isAddPapersDialogOpen = true;
         })
         .catch((error) => {
           alert("Issue occurred when fetching search results. This may be due to API issues or the CorpusID not being associated with a valid paper.");
@@ -99,8 +118,8 @@ class SearchBar extends React.Component {
           for (var i = 0; i < response.data.length; i++) {
             searches.push(response.data[i]);
           }
-          appState.project.searchResults = searches;
-          appState.project.isAddPapersDialogOpen = true;
+          this.setState({searchResults: searches})
+          // appState.project.isAddPapersDialogOpen = true;
           this.setState({display: true})
         })
         .catch((error) => {
@@ -136,15 +155,19 @@ class SearchBar extends React.Component {
           leftIconName={"search"} 
           rightElement={
             <Popover
-              content={<AddNodes />} 
+              content={<AddNodes papers={this.state.searchResults} query={this.state.query}/>} 
               target={<button onClick={this.handleSubmit} class="pt-button pt-minimal pt-intent-primary pt-icon-arrow-right"></button>}
               position={Position.BOTTOM}
-              isOpen={this.state.display}
+              isOpen={this.state.display && this.state.searchResults.length > 0}
               onClose={() => {this.setState({display: false})}}
+              autoFocus={false}
+              enforceFocus={false}
             /> 
           }
           onChange={this.handleChange}
           placeholder={"Search"}
+          onKeyPress={(e) => this.handleEnter(e)}
+          onClick={this.handleClick}
         />
         {/* <Popover
           content={

--- a/argo-scholar/src/components/panels/AddNodesPanel.jsx
+++ b/argo-scholar/src/components/panels/AddNodesPanel.jsx
@@ -9,6 +9,14 @@ import PaperResultsSubPanel from "./PaperResultsSubPanel";
 
 @observer
 class AddNodes extends React.Component {
+  constructor(props) {
+    super(props);
+    this._isMounted = false; 
+    this.state = {
+        papers: this.props.papers,
+        query: this.props.query,
+    };
+  }
   render() {
     // If input is number,
     // currently format number between 0-1 (eg. pagerank)
@@ -20,7 +28,7 @@ class AddNodes extends React.Component {
         }}
       >
         <div style={{pointerEvents: "all"}}>
-          <PaperResultsSubPanel papers={appState.project.searchResults} query={appState.project.currentQuery}/>
+          <PaperResultsSubPanel papers={this.props.papers} query={this.state.query}/>
         </div>
         
       </div>

--- a/argo-scholar/src/components/panels/AddNodesRow.jsx
+++ b/argo-scholar/src/components/panels/AddNodesRow.jsx
@@ -98,7 +98,9 @@ class AddNodesRow extends React.Component {
               // // disabled={paper.paperId in appState.graph.preprocessedRawGraph.nodesPanelData}
               disabled={buttonDisabled} 
               onClick={() => this.handleClick(this.state.paper.paperId)}>
-              {nodeHidden ? "Unhide" : "Add"}
+              {nodeHidden ? "Unhide" 
+                : buttonDisabled
+                  ? "Added" : "Add"}
             </button>
           </td>
         </tr>

--- a/argo-scholar/src/components/panels/PaperResultsSubPanel.jsx
+++ b/argo-scholar/src/components/panels/PaperResultsSubPanel.jsx
@@ -35,7 +35,9 @@ class PaperResultsSubPanel extends React.Component {
     return (
         <div>
           <table class="search-paper-table">
-            {cards}
+            <tbody>
+              {cards}
+            </tbody>
           </table> 
         </div>
     );

--- a/argo-scholar/src/stores/ProjectStore.js
+++ b/argo-scholar/src/stores/ProjectStore.js
@@ -29,9 +29,9 @@ export default class ProjectStore {
   // Also used when refreshing WorkspaceView
   @observable isFetching = true;
 
-  @observable currentQuery = '';
+  // @observable currentQuery = '';
 
-  @observable searchResults = [];
+  // @observable searchResults = [];
   /*
    * New project creation and import
    */

--- a/argo-scholar/src/styles/index.css
+++ b/argo-scholar/src/styles/index.css
@@ -216,8 +216,8 @@ td.search-result {
   word-wrap: break-word;
   white-space: normal;
   overflow: auto;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 td.search-add {


### PR DESCRIPTION
New features/changes:
- Commented out AddPapersDialog (officially replaced by popover in SearchBar.jsx)
- Deprecated global variables "currentQuery" and "searchResults" (now passes information as props)
- Users can now submit search by pressing "enter"
- Clicking the search bar field redisplays the previous search results
- Added results will have their buttons continue to be disabled but now say "Added" instead of "Add"
- Empty search results will not open an empty popover
- Increased top and bottom padding of search results